### PR TITLE
Fix missing partials folder in distribution

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -343,7 +343,7 @@ module.exports = function (grunt) {
           usemin: 'scripts/scripts.js'
         },
         cwd: '<%= yeoman.app %>',
-        src: 'views/{,*/}*.html',
+        src: 'partials/{,*/}*.html',
         dest: '.tmp/templateCache.js'
       }
     },


### PR DESCRIPTION
Grunt was preparing 'views' html files for distribution, of which there were none. Instead we are using 'partials'.
